### PR TITLE
Implement Context-Aware Equip Aliases Feature

### DIFF
--- a/issues/2025-08-24-context-aware-equip-aliases.md
+++ b/issues/2025-08-24-context-aware-equip-aliases.md
@@ -1,7 +1,7 @@
 # Context-Aware Equip Aliases
 
 **Date**: 2025-08-24  
-**Status**: Open  
+**Status**: Completed  
 **Priority**: Medium  
 **Category**: Enhancement/Commands  
 

--- a/specs/context-aware-equip-aliases.md
+++ b/specs/context-aware-equip-aliases.md
@@ -1,0 +1,125 @@
+# Context-Aware Equip Aliases Specification
+
+## Overview
+
+This specification defines the implementation of context-aware aliases for the equip command that provide more intuitive, natural language commands for players.
+
+## Core Features
+
+### Command Aliases
+- **`wear`** - For armor-type items (helmets, boots, armor, shields, etc.)
+- **`use`** - For weapon-type items (swords, axes, staves, daggers, etc.)
+
+### Behavior
+- Both aliases route to the existing `equip` command functionality
+- Include context validation to prevent inappropriate usage
+- Maintain existing `equip` command for all item types
+- Support partial item name matching (same as existing equip)
+
+## Implementation Components
+
+### 1. Item Type Detection
+
+#### Armor Detection
+Items classified as armor if they match any of:
+- **Type**: `armor`, `helmet`, `boots`, `gloves`, `shield`, `cloak`, `ring`, `amulet`
+- **Name contains**: armor type keywords
+- **Description contains**: `wear` or `armor` keywords
+
+#### Weapon Detection  
+Items classified as weapons if they match any of:
+- **Type**: `weapon`, `sword`, `axe`, `bow`, `dagger`, `staff`, `mace`, `hammer`
+- **Name contains**: weapon type keywords  
+- **Description contains**: `weapon` or `wield` keywords
+
+### 2. Command Handlers
+
+#### `wear` Command
+1. Find item in inventory by name (partial matching)
+2. Validate item exists
+3. Validate item is armor-type
+4. Route to existing equip functionality
+
+#### `use` Command  
+1. Find item in inventory by name (partial matching)
+2. Validate item exists
+3. Validate item is weapon-type
+4. Route to existing equip functionality
+
+### 3. Error Messages
+
+#### Item Not Found
+- `"You don't have a {itemName}."`
+
+#### Wrong Item Type for `wear`
+- `"You can't wear a {itemName}. Try \"equip\" or \"use\" instead."`
+
+#### Wrong Item Type for `use`
+- `"You can't use a {itemName} as a weapon. Try \"equip\" or \"wear\" instead."`
+
+## Test Scenarios
+
+### Valid Usage Tests
+1. **Armor Items**
+   - `wear chain mail` → Equips Chain Mail
+   - `wear boots` → Equips Leather Boots
+   - `wear helmet` → Equips Iron Helmet
+
+2. **Weapon Items**
+   - `use sword` → Equips Iron Sword
+   - `use staff` → Equips Wooden Staff
+   - `use dagger` → Equips Ancient Dagger
+
+### Context Validation Tests
+1. **Wrong Context**
+   - `wear sword` → Error: "You can't wear a Iron Sword..."
+   - `use boots` → Error: "You can't use a Leather Boots as a weapon..."
+
+2. **Missing Items**
+   - `wear nonexistent` → Error: "You don't have a nonexistent."
+   - `use missing` → Error: "You don't have a missing."
+
+### Edge Cases
+1. **Empty Commands**
+   - `wear` (no args) → Command usage help
+   - `use` (no args) → Command usage help
+
+2. **Partial Name Matching**
+   - `wear chain` → Matches "Chain Mail"
+   - `use iron` → Matches "Iron Sword"
+
+## Implementation Files
+
+### Primary Changes
+- **`src/gameController.ts`** - Add command registration and handlers
+- **`src/services/itemService.ts`** - Add item type detection utilities
+
+### Test Files
+- **`tests/commands/context-aware-equip.test.ts`** - Unit tests
+- **`tests/e2e/context-aware-equip.test.ts`** - End-to-end tests
+
+## Command Help Integration
+
+Update help system to include:
+- `wear <item>` - Equip armor items (helmets, boots, armor, etc.)
+- `use <item>` - Equip weapons (swords, axes, staves, etc.)
+
+## Acceptance Criteria
+
+- [ ] `wear` command only works for armor-type items
+- [ ] `use` command only works for weapon-type items  
+- [ ] Both commands route to existing equip functionality
+- [ ] Appropriate error messages for wrong item types
+- [ ] Help text updated to show new aliases
+- [ ] Existing `equip` command continues to work for all item types
+- [ ] Commands work with partial item names
+- [ ] Unit tests cover all scenarios
+- [ ] End-to-end tests verify complete functionality
+
+## Future Extensions
+
+This pattern could extend to other context-aware aliases:
+- `drink` for potions
+- `read` for books/scrolls
+- `light` for torches/candles
+- `throw` for projectiles

--- a/src/gameController.ts
+++ b/src/gameController.ts
@@ -25,6 +25,7 @@ import { ValidationResult, ActionContext } from './types/validation';
 import { HealthService, HealthStatus } from './services/healthService';
 import { EventTriggerService, TriggerContext } from './services/eventTriggerService';
 import { CharacterType, Character, CharacterSentiment, getAttributeModifier } from './types/character';
+import { Item } from './types/item';
 import { UnifiedRoomDisplayService } from './services/unifiedRoomDisplayService';
 import { TUIOutputAdapter } from './adapters/tuiOutputAdapter';
 import { stripArticles, parseTalkCommand, parseGiveCommand } from './utils/articleParser';
@@ -436,6 +437,19 @@ export class GameController {
       name: 'unequip',
       description: 'Unequip an equipped item',
       handler: async (args) => await this.handleUnequip(args.join(' '))
+    });
+
+    // Context-aware equip aliases
+    this.commandRouter.addCommand({
+      name: 'wear',
+      description: 'Equip armor items (helmets, boots, armor, etc.)',
+      handler: async (args) => await this.handleWear(args.join(' '))
+    });
+
+    this.commandRouter.addCommand({
+      name: 'use',
+      description: 'Equip weapons (swords, axes, staves, etc.)',
+      handler: async (args) => await this.handleUse(args.join(' '))
     });
 
     this.commandRouter.addCommand({
@@ -2997,6 +3011,110 @@ export class GameController {
     } catch (error) {
       console.error('Error during teleport:', error);
       this.tui.showError('Teleport failed', (error as Error)?.message);
+    }
+  }
+
+  /**
+   * Check if an item is armor-type (can be worn)
+   */
+  private isArmorItem(item: Item): boolean {
+    const armorTypes = ['armor', 'helmet', 'boots', 'gloves', 'shield', 'cloak', 'ring', 'amulet'];
+    return armorTypes.some(type => 
+      item.type === type || 
+      item.name.toLowerCase().includes(type) ||
+      item.description.toLowerCase().includes('wear') ||
+      item.description.toLowerCase().includes('armor')
+    );
+  }
+
+  /**
+   * Check if an item is weapon-type (can be used as a weapon)
+   */
+  private isWeaponItem(item: Item): boolean {
+    const weaponTypes = ['weapon', 'sword', 'axe', 'bow', 'dagger', 'staff', 'mace', 'hammer'];
+    return weaponTypes.some(type => 
+      item.type === type || 
+      item.name.toLowerCase().includes(type) ||
+      item.description.toLowerCase().includes('weapon') ||
+      item.description.toLowerCase().includes('wield')
+    );
+  }
+
+  /**
+   * Handle wearing armor items (context-aware equip alias)
+   */
+  private async handleWear(itemName: string): Promise<void> {
+    if (!this.gameStateManager.isInGame()) {
+      this.tui.display('No game is currently loaded.', MessageType.SYSTEM);
+      return;
+    }
+
+    if (!itemName) {
+      this.tui.display('Wear what?', MessageType.ERROR);
+      return;
+    }
+
+    try {
+      const characterId = await this.getCurrentCharacterId();
+
+      // Find the item in inventory that can be equipped
+      const item = await this.equipmentService.findEquippableItem(characterId, itemName);
+      if (!item) {
+        this.tui.display(`You don't have a ${itemName}.`, MessageType.ERROR);
+        return;
+      }
+
+      // Validate item is armor-type
+      if (!this.isArmorItem(item.item)) {
+        this.tui.display(`You can't wear a ${item.item.name}. Try "equip" or "use" instead.`, MessageType.ERROR);
+        return;
+      }
+
+      // Route to existing equip logic
+      return this.handleEquip(itemName);
+
+    } catch (error) {
+      console.error('Error wearing item:', error);
+      this.tui.display((error as Error).message, MessageType.ERROR);
+    }
+  }
+
+  /**
+   * Handle using weapon items (context-aware equip alias)
+   */
+  private async handleUse(itemName: string): Promise<void> {
+    if (!this.gameStateManager.isInGame()) {
+      this.tui.display('No game is currently loaded.', MessageType.SYSTEM);
+      return;
+    }
+
+    if (!itemName) {
+      this.tui.display('Use what?', MessageType.ERROR);
+      return;
+    }
+
+    try {
+      const characterId = await this.getCurrentCharacterId();
+
+      // Find the item in inventory that can be equipped
+      const item = await this.equipmentService.findEquippableItem(characterId, itemName);
+      if (!item) {
+        this.tui.display(`You don't have a ${itemName}.`, MessageType.ERROR);
+        return;
+      }
+
+      // Validate item is weapon-type
+      if (!this.isWeaponItem(item.item)) {
+        this.tui.display(`You can't use a ${item.item.name} as a weapon. Try "equip" or "wear" instead.`, MessageType.ERROR);
+        return;
+      }
+
+      // Route to existing equip logic
+      return this.handleEquip(itemName);
+
+    } catch (error) {
+      console.error('Error using item:', error);
+      this.tui.display((error as Error).message, MessageType.ERROR);
     }
   }
 

--- a/tests/commands/context-aware-equip.test.ts
+++ b/tests/commands/context-aware-equip.test.ts
@@ -1,0 +1,352 @@
+import Database from '../../src/utils/database';
+import { initializeDatabase } from '../../src/utils/initDb';
+import { GameController } from '../../src/gameController';
+import { ItemService } from '../../src/services/itemService';
+import { ItemType, EquipmentSlot } from '../../src/types/item';
+import { MockTUI } from '../mocks/mockTUI';
+
+describe('Context-Aware Equip Commands', () => {
+  let db: Database;
+  let gameController: GameController;
+  let itemService: ItemService;
+  let mockTUI: MockTUI;
+  let gameId: number;
+  let characterId: number;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    await db.connect();
+    await initializeDatabase(db);
+    
+    mockTUI = new MockTUI();
+    gameController = new GameController(db, 'test', mockTUI);
+    itemService = new ItemService(db);
+
+    // Create test game
+    const gameResult = await db.run(
+      'INSERT INTO games (name, created_at, last_played_at) VALUES (?, ?, ?)',
+      ['Test Game', new Date().toISOString(), new Date().toISOString()]
+    );
+    gameId = gameResult.lastID;
+
+    // Create test character
+    const characterResult = await db.run(
+      'INSERT INTO characters (game_id, name, type) VALUES (?, ?, ?)',
+      [gameId, 'Test Player', 'player']
+    );
+    characterId = characterResult.lastID;
+
+    // Create starting room
+    const roomResult = await db.run(
+      'INSERT INTO rooms (game_id, name, description) VALUES (?, ?, ?)',
+      [gameId, 'Test Room', 'A test room.']
+    );
+    const roomId = roomResult.lastID;
+
+    // Set up game state
+    await db.run(
+      'INSERT INTO game_state (game_id, current_room_id, character_id) VALUES (?, ?, ?)',
+      [gameId, roomId, characterId]
+    );
+
+    // Load the game
+    const game = await db.get('SELECT * FROM games WHERE id = ?', [gameId]);
+    await (gameController as any).loadSelectedGame(game, true);
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  describe('Item Type Detection', () => {
+    describe('isArmorItem', () => {
+      it('should identify armor type items', async () => {
+        // Create armor item
+        const armorId = await itemService.createItem({
+          name: 'Chain Mail',
+          description: 'A sturdy chain mail armor',
+          type: ItemType.ARMOR,
+          weight: 10,
+          value: 100,
+          stackable: false,
+          max_stack: 1
+        });
+        
+        const armor = await itemService.getItem(armorId);
+        expect(armor).toBeTruthy();
+        expect((gameController as any).isArmorItem(armor!)).toBe(true);
+      });
+
+      it('should identify helmet items by name', async () => {
+        const helmetId = await itemService.createItem({
+          name: 'Iron Helmet',
+          description: 'A protective iron helmet',
+          type: ItemType.MISC,
+          weight: 2,
+          value: 50,
+          stackable: false,
+          max_stack: 1
+        });
+        
+        const helmet = await itemService.getItem(helmetId);
+        expect((gameController as any).isArmorItem(helmet!)).toBe(true);
+      });
+
+      it('should identify armor by description keywords', async () => {
+        const cloakId = await itemService.createItem({
+          name: 'Mystic Robe',
+          description: 'A magical robe you can wear for protection',
+          type: ItemType.MISC,
+          weight: 1,
+          value: 75,
+          stackable: false,
+          max_stack: 1
+        });
+        
+        const cloak = await itemService.getItem(cloakId);
+        expect((gameController as any).isArmorItem(cloak!)).toBe(true);
+      });
+
+      it('should not identify weapon items as armor', async () => {
+        const swordId = await itemService.createItem({
+          name: 'Iron Sword',
+          description: 'A sharp iron sword',
+          type: ItemType.WEAPON,
+          weight: 3,
+          value: 80,
+          stackable: false,
+          max_stack: 1
+        });
+        
+        const sword = await itemService.getItem(swordId);
+        expect((gameController as any).isArmorItem(sword!)).toBe(false);
+      });
+    });
+
+    describe('isWeaponItem', () => {
+      it('should identify weapon type items', async () => {
+        const swordId = await itemService.createItem({
+          name: 'Iron Sword',
+          description: 'A sharp iron sword',
+          type: ItemType.WEAPON,
+          weight: 3,
+          value: 80,
+          stackable: false,
+          max_stack: 1
+        });
+        
+        const sword = await itemService.getItem(swordId);
+        expect((gameController as any).isWeaponItem(sword!)).toBe(true);
+      });
+
+      it('should identify weapons by name keywords', async () => {
+        const axeId = await itemService.createItem({
+          name: 'Battle Axe',
+          description: 'A heavy battle axe',
+          type: ItemType.MISC,
+          weight: 5,
+          value: 120,
+          stackable: false,
+          max_stack: 1
+        });
+        
+        const axe = await itemService.getItem(axeId);
+        expect((gameController as any).isWeaponItem(axe!)).toBe(true);
+      });
+
+      it('should identify weapons by description keywords', async () => {
+        const staffId = await itemService.createItem({
+          name: 'Wooden Rod',
+          description: 'A magical rod you can wield as a weapon',
+          type: ItemType.MISC,
+          weight: 2,
+          value: 60,
+          stackable: false,
+          max_stack: 1
+        });
+        
+        const staff = await itemService.getItem(staffId);
+        expect((gameController as any).isWeaponItem(staff!)).toBe(true);
+      });
+
+      it('should not identify armor items as weapons', async () => {
+        const armorId = await itemService.createItem({
+          name: 'Chain Mail',
+          description: 'A sturdy chain mail armor',
+          type: ItemType.ARMOR,
+          weight: 10,
+          value: 100,
+          stackable: false,
+          max_stack: 1
+        });
+        
+        const armor = await itemService.getItem(armorId);
+        expect((gameController as any).isWeaponItem(armor!)).toBe(false);
+      });
+    });
+  });
+
+  describe('Wear Command', () => {
+    beforeEach(async () => {
+      // Create armor items in inventory
+      const chainMailId = await itemService.createItem({
+        name: 'Chain Mail',
+        description: 'A sturdy chain mail armor',
+        type: ItemType.ARMOR,
+        weight: 10,
+        value: 100,
+        stackable: false,
+        max_stack: 1,
+        equipment_slot: EquipmentSlot.BODY
+      });
+
+      const bootsId = await itemService.createItem({
+        name: 'Leather Boots',
+        description: 'Comfortable leather boots',
+        type: ItemType.ARMOR,
+        weight: 2,
+        value: 30,
+        stackable: false,
+        max_stack: 1,
+        equipment_slot: EquipmentSlot.FOOT
+      });
+
+      const swordId = await itemService.createItem({
+        name: 'Iron Sword',
+        description: 'A sharp iron sword',
+        type: ItemType.WEAPON,
+        weight: 3,
+        value: 80,
+        stackable: false,
+        max_stack: 1,
+        equipment_slot: EquipmentSlot.HAND
+      });
+
+      // Add items to character inventory
+      await itemService.addItemToCharacter(characterId, chainMailId, 1);
+      await itemService.addItemToCharacter(characterId, bootsId, 1);
+      await itemService.addItemToCharacter(characterId, swordId, 1);
+    });
+
+    it('should equip armor items successfully', async () => {
+      mockTUI.clearMessages();
+      
+      await (gameController as any).processCommand('wear chain mail');
+      
+      const messages = mockTUI.getMessages();
+      expect(messages.some(msg => msg.includes('You equipped Chain Mail'))).toBe(true);
+    });
+
+    it('should work with partial names', async () => {
+      mockTUI.clearMessages();
+      
+      await (gameController as any).processCommand('wear boots');
+      
+      const messages = mockTUI.getMessages();
+      expect(messages.some(msg => msg.includes('You equipped Leather Boots'))).toBe(true);
+    });
+
+    it('should reject weapon items', async () => {
+      mockTUI.clearMessages();
+      
+      await (gameController as any).processCommand('wear sword');
+      
+      const messages = mockTUI.getMessages();
+      expect(messages.some(msg => 
+        msg.includes("You can't wear a Iron Sword") && 
+        msg.includes('Try "equip" or "use" instead')
+      )).toBe(true);
+    });
+
+    it('should handle missing items', async () => {
+      mockTUI.clearMessages();
+      
+      await (gameController as any).processCommand('wear nonexistent');
+      
+      const messages = mockTUI.getMessages();
+      expect(messages.some(msg => msg.includes("You don't have a nonexistent"))).toBe(true);
+    });
+  });
+
+  describe('Use Command', () => {
+    beforeEach(async () => {
+      // Create weapon items in inventory
+      const swordId = await itemService.createItem({
+        name: 'Iron Sword',
+        description: 'A sharp iron sword',
+        type: ItemType.WEAPON,
+        weight: 3,
+        value: 80,
+        stackable: false,
+        max_stack: 1,
+        equipment_slot: EquipmentSlot.HAND
+      });
+
+      const staffId = await itemService.createItem({
+        name: 'Wooden Staff',
+        description: 'A magical wooden staff',
+        type: ItemType.WEAPON,
+        weight: 2,
+        value: 60,
+        stackable: false,
+        max_stack: 1,
+        equipment_slot: EquipmentSlot.HAND
+      });
+
+      const bootsId = await itemService.createItem({
+        name: 'Leather Boots',
+        description: 'Comfortable leather boots',
+        type: ItemType.ARMOR,
+        weight: 2,
+        value: 30,
+        stackable: false,
+        max_stack: 1,
+        equipment_slot: EquipmentSlot.FOOT
+      });
+
+      // Add items to character inventory
+      await itemService.addItemToCharacter(characterId, swordId, 1);
+      await itemService.addItemToCharacter(characterId, staffId, 1);
+      await itemService.addItemToCharacter(characterId, bootsId, 1);
+    });
+
+    it('should equip weapon items successfully', async () => {
+      mockTUI.clearMessages();
+      
+      await (gameController as any).processCommand('use sword');
+      
+      const messages = mockTUI.getMessages();
+      expect(messages.some(msg => msg.includes('You equipped Iron Sword'))).toBe(true);
+    });
+
+    it('should work with partial names', async () => {
+      mockTUI.clearMessages();
+      
+      await (gameController as any).processCommand('use staff');
+      
+      const messages = mockTUI.getMessages();
+      expect(messages.some(msg => msg.includes('You equipped Wooden Staff'))).toBe(true);
+    });
+
+    it('should reject armor items', async () => {
+      mockTUI.clearMessages();
+      
+      await (gameController as any).processCommand('use boots');
+      
+      const messages = mockTUI.getMessages();
+      expect(messages.some(msg => 
+        msg.includes("You can't use a Leather Boots as a weapon") && 
+        msg.includes('Try "equip" or "wear" instead')
+      )).toBe(true);
+    });
+
+    it('should handle missing items', async () => {
+      mockTUI.clearMessages();
+      
+      await (gameController as any).processCommand('use missing');
+      
+      const messages = mockTUI.getMessages();
+      expect(messages.some(msg => msg.includes("You don't have a missing"))).toBe(true);
+    });
+  });
+});

--- a/tests/e2e/context-aware-equip.test.ts
+++ b/tests/e2e/context-aware-equip.test.ts
@@ -1,0 +1,198 @@
+import Database from '../../src/utils/database';
+import { initializeDatabase, createGameWithRooms } from '../../src/utils/initDb';
+import { GameController } from '../../src/gameController';
+import { ItemService } from '../../src/services/itemService';
+import { ItemType, EquipmentSlot } from '../../src/types/item';
+import { MockTUI } from '../mocks/mockTUI';
+
+describe('Context-Aware Equip Commands E2E', () => {
+  let db: Database;
+  let gameController: GameController;
+  let itemService: ItemService;
+  let mockTUI: MockTUI;
+  let gameId: number;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    await db.connect();
+    await initializeDatabase(db);
+    
+    mockTUI = new MockTUI();
+    gameController = new GameController(db, 'test', mockTUI);
+    itemService = new ItemService(db);
+
+    // Create a complete game with rooms using the helper function
+    const uniqueGameName = `Context Equip E2E Test ${Date.now()}-${Math.random()}`;
+    gameId = await createGameWithRooms(db, uniqueGameName);
+    
+    // Load the game
+    const game = await db.get('SELECT * FROM games WHERE id = ?', [gameId]);
+    await (gameController as any).loadSelectedGame(game, true);
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  describe('Full Game Integration', () => {
+    it('should complete the full workflow: wear, use, equipment', async () => {
+      // Get the character ID from the game
+      const gameState = await db.get('SELECT * FROM game_state WHERE game_id = ?', [gameId]);
+      const characterId = gameState.character_id;
+
+      // Create test items and add directly to inventory (skipping pickup complexity)
+      const chainMailId = await itemService.createItem({
+        name: 'Chain Mail Armor',
+        description: 'Heavy armor for protection',
+        type: ItemType.ARMOR,
+        weight: 15,
+        value: 200,
+        stackable: false,
+        max_stack: 1,
+        equipment_slot: EquipmentSlot.BODY,
+        armor_rating: 5
+      });
+
+      const ironSwordId = await itemService.createItem({
+        name: 'Iron Sword',
+        description: 'A sharp iron sword for battle',
+        type: ItemType.WEAPON,
+        weight: 3,
+        value: 150,
+        stackable: false,
+        max_stack: 1,
+        equipment_slot: EquipmentSlot.HAND
+      });
+
+      const leatherBootsId = await itemService.createItem({
+        name: 'Leather Boots',
+        description: 'Comfortable leather boots',
+        type: ItemType.ARMOR,
+        weight: 2,
+        value: 50,
+        stackable: false,
+        max_stack: 1,
+        equipment_slot: EquipmentSlot.FOOT,
+        armor_rating: 1
+      });
+
+      // Add items directly to character inventory
+      await itemService.addItemToCharacter(characterId, chainMailId, 1);
+      await itemService.addItemToCharacter(characterId, ironSwordId, 1);
+      await itemService.addItemToCharacter(characterId, leatherBootsId, 1);
+
+      // 1. Check inventory
+      mockTUI.clearMessages();
+      await (gameController as any).processCommand('inventory');
+      let messages = mockTUI.getMessages();
+      expect(messages.some(msg => msg.includes('Chain Mail Armor'))).toBe(true);
+      expect(messages.some(msg => msg.includes('Iron Sword'))).toBe(true);
+      expect(messages.some(msg => msg.includes('Leather Boots'))).toBe(true);
+
+      // 2. Use context-aware commands
+      mockTUI.clearMessages();
+      
+      // Wear armor items
+      await (gameController as any).processCommand('wear chain mail');
+      await (gameController as any).processCommand('wear boots');
+      
+      // Use weapon
+      await (gameController as any).processCommand('use sword');
+
+      messages = mockTUI.getMessages();
+      expect(messages.some(msg => msg.includes('You equipped Chain Mail Armor'))).toBe(true);
+      expect(messages.some(msg => msg.includes('You equipped Leather Boots'))).toBe(true);
+      expect(messages.some(msg => msg.includes('You equipped Iron Sword'))).toBe(true);
+
+      // 3. Check equipment status
+      mockTUI.clearMessages();
+      await (gameController as any).processCommand('equipment');
+      messages = mockTUI.getMessages();
+      expect(messages.some(msg => msg.includes('Chain Mail Armor'))).toBe(true);
+      expect(messages.some(msg => msg.includes('Iron Sword'))).toBe(true);
+      expect(messages.some(msg => msg.includes('Leather Boots'))).toBe(true);
+
+      // 4. Test error cases (need to unequip items first since findEquippableItem only finds unequipped items)
+      await (gameController as any).processCommand('unequip sword');
+      await (gameController as any).processCommand('unequip boots');
+      
+      mockTUI.clearMessages();
+      
+      // Try to wear a weapon
+      await (gameController as any).processCommand('wear sword');
+      messages = mockTUI.getMessages();
+      expect(messages.some(msg => 
+        msg.includes("You can't wear a Iron Sword") && 
+        msg.includes('Try "equip" or "use" instead')
+      )).toBe(true);
+
+      // Try to use armor as weapon
+      mockTUI.clearMessages();
+      await (gameController as any).processCommand('use boots');
+      messages = mockTUI.getMessages();
+      expect(messages.some(msg => 
+        msg.includes("You can't use a Leather Boots as a weapon") && 
+        msg.includes('Try "equip" or "wear" instead')
+      )).toBe(true);
+
+      // 5. Test that regular equip still works
+      mockTUI.clearMessages();
+      await (gameController as any).processCommand('unequip sword');
+      await (gameController as any).processCommand('equip sword');
+      messages = mockTUI.getMessages();
+      expect(messages.some(msg => msg.includes('You equipped Iron Sword'))).toBe(true);
+    });
+
+    it('should show helpful error messages for non-existent items', async () => {
+      mockTUI.clearMessages();
+      
+      await (gameController as any).processCommand('wear nonexistent');
+      await (gameController as any).processCommand('use missing');
+      
+      const messages = mockTUI.getMessages();
+      expect(messages.some(msg => msg.includes("You don't have a nonexistent"))).toBe(true);
+      expect(messages.some(msg => msg.includes("You don't have a missing"))).toBe(true);
+    });
+
+    it('should work with partial name matching', async () => {
+      const gameState = await db.get('SELECT * FROM game_state WHERE game_id = ?', [gameId]);
+      const characterId = gameState.character_id;
+
+      // Create items with long names
+      const plateMailId = await itemService.createItem({
+        name: 'Enchanted Plate Mail of Protection',
+        description: 'Magical plate armor',
+        type: ItemType.ARMOR,
+        weight: 25,
+        value: 500,
+        stackable: false,
+        max_stack: 1,
+        equipment_slot: EquipmentSlot.BODY
+      });
+
+      const bastardSwordId = await itemService.createItem({
+        name: 'Bastard Sword of Flame',
+        description: 'A flaming two-handed sword',
+        type: ItemType.WEAPON,
+        weight: 6,
+        value: 300,
+        stackable: false,
+        max_stack: 1,
+        equipment_slot: EquipmentSlot.HAND
+      });
+
+      // Add to inventory
+      await itemService.addItemToCharacter(characterId, plateMailId, 1);
+      await itemService.addItemToCharacter(characterId, bastardSwordId, 1);
+
+      // Test partial matching
+      mockTUI.clearMessages();
+      await (gameController as any).processCommand('wear plate');
+      await (gameController as any).processCommand('use bastard');
+
+      const messages = mockTUI.getMessages();
+      expect(messages.some(msg => msg.includes('You equipped Enchanted Plate Mail of Protection'))).toBe(true);
+      expect(messages.some(msg => msg.includes('You equipped Bastard Sword of Flame'))).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `wear` command for armor items (helmets, boots, armor, shields, etc.)
- Add `use` command for weapons (swords, axes, staves, daggers, etc.)
- Implement smart item type detection with context validation
- Provide intuitive, natural language commands for better player experience

## Key Features
- **Smart Type Detection**: Identifies armor/weapons by type, name keywords, and descriptions
- **Context Validation**: Prevents inappropriate usage with helpful error messages
- **Partial Name Matching**: Works with existing item disambiguation system
- **Backward Compatibility**: Existing `equip` command continues to work for all items
- **Help Integration**: New commands appear in help with proper descriptions

## Examples
```
> wear chain mail     ✅ Equips Chain Mail
> use iron sword      ✅ Equips Iron Sword  
> wear sword          ❌ "You can't wear a Iron Sword. Try 'equip' or 'use' instead."
> use boots           ❌ "You can't use a Leather Boots as a weapon. Try 'equip' or 'wear' instead."
```

## Test Coverage
- **19 comprehensive tests** covering all functionality
- Unit tests for item type detection logic
- Integration tests for command handlers with game state
- End-to-end tests for complete gameplay workflows
- Error handling for missing items, wrong item types, and edge cases

## Files Changed
- `src/gameController.ts` - Core implementation with item type detection and command handlers
- `issues/2025-08-24-context-aware-equip-aliases.md` - Issue marked as completed
- `specs/context-aware-equip-aliases.md` - Feature specification
- `tests/commands/context-aware-equip.test.ts` - Unit and integration tests
- `tests/e2e/context-aware-equip.test.ts` - End-to-end tests

## Test Results
All tests pass cleanly:
- ✅ 19/19 context-aware equip tests passing
- ✅ Equipment service regression tests passing
- ✅ No hanging Jest processes

This enhancement significantly improves player experience with more natural, intuitive commands while maintaining full compatibility with existing functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)